### PR TITLE
Discontinue execution, and return callback() if delta is zero. Resolves issue #2.

### DIFF
--- a/lib/osascript-vol-ctrl.js
+++ b/lib/osascript-vol-ctrl.js
@@ -79,7 +79,7 @@
     get(function (err, cur, muted) {
       // OS X BUG
       // The lowest volume setting is 0 < x < 1, but it reads as 0
-      // Thus it's not possible to tell muted vs 
+      // Thus it's not possible to tell muted vs
       num = parseInt(num, 10);
       // TODO make this an error
       if (isNaN(num)) {
@@ -198,6 +198,8 @@
       } else {
         delta = level - cur;
       }
+
+      if (delta === 0) return callback();
 
       steps = unroll(cur, delta, time, {
         MIN_STEP: MIN_STEP


### PR DESCRIPTION
This prevents the "Error: write after end" error.